### PR TITLE
README section how to install the tool through nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,5 @@ Install it by `stack`:
     $ cd ghcprofview-hs/
     $ stack install
 
+Installing it by `nix-shell`:
+    $ nix-shell -p haskellPackages.ghcprofview


### PR DESCRIPTION
I wasn't able install ghcprofview via `stack install` due some problem with `gi-gdk`, but
after some research I discovered that ghcprofview is available through nix and it worked out for me.

